### PR TITLE
Update server_audit.cc

### DIFF
--- a/plugin/server_audit/server_audit.cc
+++ b/plugin/server_audit/server_audit.cc
@@ -1184,7 +1184,8 @@ static int write_log(const char *message, size_t len, int take_lock)
         mysql_prlock_wrlock(&lock_operations);
         allow_rotate= 1;
       }
-      if (!(is_active= (logger_write_r(logfile, allow_rotate, message, len) ==
+      if (logfile &&
+	  !(is_active= (logger_write_r(logfile, allow_rotate, message, len) ==
                         (int) len)))
       {
         ++log_write_failures;


### PR DESCRIPTION
Fix the crash issue caused by the plugin being stopped after switching from a read lock to a write lock.

*Issue #, if available:*
If auditing is disabled by another thread just after the read lock is released but before acquiring the write lock, it will cause the instance to crash.

*Description of changes:*
Check if the logfile object has been released.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
