### PR TITLE
Backport two commits for MDEV-28177 and MDEV-28429

### DIFF
--- a/plugin/server_audit/server_audit.cc
+++ b/plugin/server_audit/server_audit.cc
@@ -1962,6 +1962,9 @@ int get_db_mysql57(MYSQL_THD thd, char **name, size_t *len)
 #ifdef __x86_64__
     db_off= 608;
     db_len_off= 616;
+#elif __aarch64__
+    db_off= 632;
+    db_len_off= 640;
 #else
     db_off= 0;
     db_len_off= 0;
@@ -1972,6 +1975,9 @@ int get_db_mysql57(MYSQL_THD thd, char **name, size_t *len)
 #ifdef __x86_64__
     db_off= 536;
     db_len_off= 544;
+#elif __aarch64__
+    db_off= 552;
+    db_len_off= 560;
 #else
     db_off= 0;
     db_len_off= 0;

--- a/plugin/server_audit/server_audit.cc
+++ b/plugin/server_audit/server_audit.cc
@@ -17,7 +17,7 @@
    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335 USA */
 
 #define PLUGIN_VERSION 0x104
-#define PLUGIN_STR_VERSION "1.4.11"
+#define PLUGIN_STR_VERSION "1.4.14"
 
 #define _my_thread_var loc_thread_var
 
@@ -849,7 +849,19 @@ static unsigned long long query_counter= 1;
 
 static struct connection_info *get_loc_info(MYSQL_THD thd)
 {
+  /*
+    This is the original code and supposed to be returned
+    bach to this as the MENT-1438 is finally understood/resolved.
   return (struct connection_info *) THDVAR(thd, loc_info);
+  */
+  struct connection_info *ci= (struct connection_info *) THDVAR(thd, loc_info);
+  if ((size_t) ci->user_length > sizeof(ci->user))
+  {
+    ci->user_length= 0;
+    ci->host_length= 0;
+    ci->ip_length= 0;
+  }
+  return ci;
 }
 
 
@@ -1219,6 +1231,16 @@ static size_t log_header(char *message, size_t message_len,
   {
     host_len= userip_len;
     host= userip;
+  }
+
+  /*
+    That was added to find the possible cause of the MENT-1438.
+    Supposed to be removed after that.
+  */
+  if (username_len > 1024)
+  {
+    username= "unknown_user";
+    username_len= (unsigned int) strlen(username);
   }
 
   if (output_type == OUTPUT_SYSLOG)


### PR DESCRIPTION
The current version is based on https://github.com/MariaDB/server/commit/d7af7bfc, and after this commit there are two more for fixing:
- [MDEV-28177](https://jira.mariadb.org/browse/MDEV-28177): MySQL 5.7.33 fails to install audit plugin for Mariadb-10.2.43 version on aarch64 platform
- [MDEV-28429](https://jira.mariadb.org/browse/MDEV-28429): audit plugin report OOOOO

Both commits can be backported without conflicts, except for the `PLUGIN_STR_VERSION`.