### PR TITLE
Modify MTR test for compatibility with 9.1

### DIFF
--- a/mysql-test/suite/server_audit/r/server_audit.result
+++ b/mysql-test/suite/server_audit/r/server_audit.result
@@ -61,7 +61,7 @@ server_audit_excl_users
 Generate audit log by connecting using non-existing user
 =======================================================================
 connect(localhost,no_such_user,,mysql,MASTER_PORT,MASTER_SOCKET);
-ERROR 28000: Access denied for user 'no_such_user'@'localhost' (using password: NO)
+Got one of the listed errors
 
 =======================================================================
 Generate audit log with different parameter values and queries
@@ -259,7 +259,7 @@ set global server_audit_incl_users='root, plug_dest';
 CREATE USER plug IDENTIFIED WITH 'test_plugin_server' AS 'plug_dest';
 CREATE USER plug_dest IDENTIFIED BY 'plug_dest_passwd';
 connect(localhost,plug,plug_dest,test,MYSQL_PORT,MYSQL_SOCK);
-ERROR 28000: Access denied for user 'plug'@'localhost' (using password: YES)
+Got one of the listed errors
 GRANT PROXY ON plug_dest TO plug;
 select USER(),CURRENT_USER();
 USER()	CURRENT_USER()

--- a/mysql-test/suite/server_audit/t/server_audit.test
+++ b/mysql-test/suite/server_audit/t/server_audit.test
@@ -67,7 +67,7 @@ source include/wait_for_line_count_in_file.inc;
 --echo Generate audit log by connecting using non-existing user
 --echo =======================================================================
 --replace_result $MASTER_MYSOCK MASTER_SOCKET $MASTER_MYPORT MASTER_PORT
---error ER_ACCESS_DENIED_ERROR
+--error ER_ACCESS_DENIED_ERROR, ER_ACCESS_DENIED_NO_PROXY_GRANT
 connect (con1,localhost,no_such_user,,mysql);
 let SEARCH_COUNT= 8;
 source include/wait_for_line_count_in_file.inc;
@@ -225,7 +225,7 @@ CREATE USER plug IDENTIFIED WITH 'test_plugin_server' AS 'plug_dest';
 CREATE USER plug_dest IDENTIFIED BY 'plug_dest_passwd';
 --sleep 2
 --replace_result $MASTER_MYPORT MYSQL_PORT $MASTER_MYSOCK MYSQL_SOCK
---error ER_ACCESS_DENIED_ERROR
+--error ER_ACCESS_DENIED_ERROR, ER_ACCESS_DENIED_NO_PROXY_GRANT
 connect(plug_con,localhost,plug,plug_dest);
 --sleep 2
 GRANT PROXY ON plug_dest TO plug;
@@ -273,7 +273,7 @@ uninstall plugin test_plugin_server;
 --echo =======================================================================
 --echo Dump the audit logs, replace the timestamp and the hostname with constant values
 --echo =======================================================================
---replace_regex /[0-9]* [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\,[^,]*\,([^,]*)\,([^,]*)\,[0-9][0-9]*\,[0-9][0-9]*\,/TIME,HOSTNAME,\1,\2,CONNECTION_ID,QUERY_ID,/
+--replace_regex /[0-9]* [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\,[^,]*\,([^,]*)\,([^,]*)\,[0-9][0-9]*\,[0-9][0-9]*\,/TIME,HOSTNAME,\1,\2,CONNECTION_ID,QUERY_ID,/ /6126/1045/ # Unify error codes across MySQL versions
 --exec cat $MYSQLD_DATADIR/server_audit.log;
 
 --echo


### PR DESCRIPTION
https://github.com/mysql/mysql-server/commit/c62af60 modified error messages to specify the reason for an access denied error, specifically introducing ER_ACCESS_DENIED_NO_PROXY_GRANT. The Audit Plugin is still compatible with MySQL 9.1, but the test must be updated to expect the new error code.


```
==============================================================================
                  TEST NAME                       RESULT  TIME (ms) COMMENT
------------------------------------------------------------------------------
[ 50%] server_audit.server_audit                 [ pass ]  10674
[100%] shutdown_report                           [ pass ]       
------------------------------------------------------------------------------
The servers were restarted 0 times
The servers were reinitialized 0 times
Spent 10.674 of 21 seconds executing testcases

Completed: All 2 tests were successful.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
